### PR TITLE
Fix ALLOW_NONE_AUTHENTICATION typos

### DIFF
--- a/3/debian-9/rootfs/entrypoint.sh
+++ b/3/debian-9/rootfs/entrypoint.sh
@@ -5,7 +5,7 @@
 ## param $1   Input name
 ##
 authentication_enabled_error() {
-    echo "The $1 environment variable does not enable authentication. Set the environment variable ALLOW_NONE_AUTHENTICAION=yes to allow the container to be started without authentication. This is recommended only for development."
+    echo "The $1 environment variable does not enable authentication. Set the environment variable ALLOW_NONE_AUTHENTICATION=yes to allow the container to be started without authentication. This is recommended only for development."
     exit 1
 }
 

--- a/3/ol-7/rootfs/entrypoint.sh
+++ b/3/ol-7/rootfs/entrypoint.sh
@@ -5,7 +5,7 @@
 ## param $1   Input name
 ##
 authentication_enabled_error() {
-    echo "The $1 environment variable does not enable authentication. Set the environment variable ALLOW_NONE_AUTHENTICAION=yes to allow the container to be started without authentication. This is recommended only for development."
+    echo "The $1 environment variable does not enable authentication. Set the environment variable ALLOW_NONE_AUTHENTICATION=yes to allow the container to be started without authentication. This is recommended only for development."
     exit 1
 }
 


### PR DESCRIPTION
This change fixes two typos of the `ALLOW_NONE_AUTHENTICATION` environment variable. 

They don't directly affect the functionality of the image, however, can confuse users if they copy-paste the environment variable name from any echo messages on the terminal. (as was my case)
