### PR TITLE
fix auth flags to check client instead of peer auto tls flag

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -149,7 +149,7 @@ etcdctl_auth_flags() {
     local -a authFlags=()
 
     ! is_empty_value "$ETCD_ROOT_PASSWORD" && authFlags+=("--user" "root:$ETCD_ROOT_PASSWORD")
-    if [[ $ETCD_PEER_AUTO_TLS = true ]]; then
+    if [[ $ETCD_AUTO_TLS = true ]]; then
         authFlags+=("--cert" "${ETCD_DATA_DIR}/fixtures/client/cert.pem" "--key" "${ETCD_DATA_DIR}/fixtures/client/key.pem")
     else
         [[ -f "$ETCD_CERT_FILE" ]] && [[ -f "$ETCD_KEY_FILE" ]] && authFlags+=("--cert" "$ETCD_CERT_FILE" "--key" "$ETCD_KEY_FILE")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
fix a bug in the scripts that references the peer auto tls environment variable when using etcdctl client

This currently causes a problem if you run with auto-tls enabled for peer but not clients

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
you can run with auto-tls enabled for peer and disabled for clients

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
