### PR TITLE
feat: allow modify ETCD_INIT_SNAPSHOTS_DIR

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/etcd-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/etcd-env.sh
@@ -28,6 +28,7 @@ etcd_env_vars=(
     ETCD_DISASTER_RECOVERY
     ETCD_ON_K8S
     ETCD_INIT_SNAPSHOT_FILENAME
+    ETCD_INIT_SNAPSHOTS_DIR
     ETCDCTL_API
     ETCD_NAME
     ETCD_LOG_LEVEL
@@ -64,7 +65,7 @@ export ETCD_VOLUME_DIR="/bitnami/etcd"
 export ETCD_BIN_DIR="${ETCD_BASE_DIR}/sbin"
 export ETCD_DATA_DIR="${ETCD_VOLUME_DIR}/data"
 export ETCD_SNAPSHOTS_DIR="/snapshots"
-export ETCD_INIT_SNAPSHOTS_DIR="/init-snapshot"
+export ETCD_INIT_SNAPSHOTS_DIR="${ETCD_INIT_SNAPSHOTS_DIR:-/init-snapshot}"
 export ETCD_NEW_MEMBERS_ENV_FILE="${ETCD_DATA_DIR}/new_member_envs"
 export PATH="${ETCD_BIN_DIR}:${PATH}"
 

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -38,7 +38,7 @@ etcd_validate() {
     else
         is_empty_value "$ETCD_ROOT_PASSWORD" && print_validation_error "The ETCD_ROOT_PASSWORD environment variable is empty or not set. Set the environment variable ALLOW_NONE_AUTHENTICATION=yes to allow a blank password. This is only recommended for development environments."
     fi
-    if is_boolean_yes "$ETCD_START_FROM_SNAPSHOT" && [[ ! -f "/init-snapshot/${ETCD_INIT_SNAPSHOT_FILENAME}" ]]; then
+    if is_boolean_yes "$ETCD_START_FROM_SNAPSHOT" && [[ ! -f "${ETCD_INIT_SNAPSHOTS_DIR}/${ETCD_INIT_SNAPSHOT_FILENAME}" ]]; then
         print_validation_error "You are trying to initialize etcd from a snapshot, but no snapshot was found. Set the environment variable ETCD_INIT_SNAPSHOT_FILENAME with the snapshot filename and mount it at '/init-snapshot' directory."
     fi
 
@@ -378,7 +378,7 @@ etcd_initialize() {
             fi
         fi
         if is_boolean_yes "$ETCD_START_FROM_SNAPSHOT"; then
-            if [[ -f "/init-snapshot/${ETCD_INIT_SNAPSHOT_FILENAME}" ]]; then
+            if [[ -f "${ETCD_INIT_SNAPSHOTS_DIR}/${ETCD_INIT_SNAPSHOT_FILENAME}" ]]; then
                 info "Restoring snapshot before initializing etcd cluster"
                 local -a restore_args=("--data-dir" "$ETCD_DATA_DIR")
                 if [[ ${#initial_members[@]} -gt 1 ]]; then
@@ -391,7 +391,7 @@ etcd_initialize() {
                         "--initial-advertise-peer-urls" "$ETCD_INITIAL_ADVERTISE_PEER_URLS"
                     )
                 fi
-                debug_execute etcdctl snapshot restore "/init-snapshot/${ETCD_INIT_SNAPSHOT_FILENAME}" "${restore_args[@]}"
+                debug_execute etcdctl snapshot restore "${ETCD_INIT_SNAPSHOTS_DIR}/${ETCD_INIT_SNAPSHOT_FILENAME}" "${restore_args[@]}"
                 debug_execute etcd_store_member_id &
             else
                 error "There was no snapshot to restore!"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Allow read ETCD_INIT_SNAPSHOTS_DIR from envirorment. So user can mount snapshot file to different path. In [etcd chart](https://github.com/bitnami/charts/tree/master/bitnami/etcd), if config startFromSnapshot.existingClaim and disasterRecovery.pvc.existingClaim the same, pod will mount the volume twice which cause problem. [PR](https://github.com/bitnami/charts/pull/4940) add support for such feature. but after breaking refactor, disasterRecovery directory is fix to /init-snapshot. After this pr accept. I can do this feature in etcd chart. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
