### PR TITLE
Select just first URI value using parse_uri function to handle possible array of strings

### DIFF
--- a/3/debian-10/prebuildfs/opt/bitnami/scripts/libnet.sh
+++ b/3/debian-10/prebuildfs/opt/bitnami/scripts/libnet.sh
@@ -97,6 +97,9 @@ is_hostname_resolved() {
 parse_uri() {
     local uri="${1:?uri is missing}"
     local component="${2:?component is missing}"
+    # Environment variable, like ETCD_ADVERTISE_CLIENT_URLS might be list, not single string. For that reason, we have to
+    # choose just first value, separated by comma, to prevent missfunctionality.
+    local first_uri=$(echo $uri | awk -F \, '{print $1}')
 
     # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
     # additional sub-expressions to split authority into userinfo, host and port
@@ -138,7 +141,7 @@ parse_uri() {
             return 1
             ;;
     esac
-    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
+    [[ "$first_uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
 }
 
 ########################


### PR DESCRIPTION
Select just first URI value using parse_uri function to handle possible array of strings.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The function parse_uri is not capable of handling array of strings and it's failing, please see [bug report](https://github.com/bitnami/charts/issues/8233).

This patch is selecting just first URI from (possible) array, so regular expression is applied to just this string, which ensure, that parsing is successful.

**Benefits**

Patch make sure that there is just one URI parsed, not list of URI's.

**Possible drawbacks**

Not sure if parse_uri doesn't count with multiple values somewhere else, even thought it doesn't seem like this.

**Applicable issues**

- Fixes https://github.com/bitnami/charts/issues/8233

**Additional information**

N/A