### PR TITLE
fix: add insecure-skip-tls-verify flag when using auto tls

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -287,7 +287,7 @@ etcdctl_auth_flags() {
 
     ! is_empty_value "$ETCD_ROOT_PASSWORD" && authFlags+=("--user" "root:$ETCD_ROOT_PASSWORD")
     if [[ $ETCD_AUTO_TLS = true ]]; then
-        authFlags+=("--cert" "${ETCD_DATA_DIR}/fixtures/client/cert.pem" "--key" "${ETCD_DATA_DIR}/fixtures/client/key.pem")
+        authFlags+=("--cert" "${ETCD_DATA_DIR}/fixtures/client/cert.pem" "--key" "${ETCD_DATA_DIR}/fixtures/client/key.pem" "--insecure-skip-tls-verify")
     else
         [[ -f "$ETCD_CERT_FILE" ]] && [[ -f "$ETCD_KEY_FILE" ]] && authFlags+=("--cert" "$ETCD_CERT_FILE" "--key" "$ETCD_KEY_FILE")
         [[ -f "$ETCD_TRUSTED_CA_FILE" ]] && authFlags+=("--cacert" "$ETCD_TRUSTED_CA_FILE")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Hi, I found that when using auto tls, we don't set the insecure-skip-tls-verify flag.
So that we can't turn on rbac in etcd.
Because this line will failed:

https://github.com/bitnami/bitnami-docker-etcd/blob/8cf4e60f5c5012bc24bf9039c5f203c850cce5f1/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh#L340

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

We can use auto tls and rbac function.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

IMO, I think we should add some logs in this line:
https://github.com/bitnami/bitnami-docker-etcd/blob/8cf4e60f5c5012bc24bf9039c5f203c850cce5f1/3/debian-10/rootfs/opt/bitnami/scripts/libetcd.sh#L340

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
