### PR TITLE
Remove member_id persist & self removal

### DIFF
--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
@@ -13,6 +13,10 @@ set -o nounset
 # Load etcd environment settings
 . /opt/bitnami/scripts/etcd-env.sh
 
+if is_boolean_yes "$ETCD_DISABLE_PRESTOP"; then
+    return 0
+fi
+
 endpoints="$(etcdctl_get_endpoints true)"
 if is_empty_value "${endpoints}"; then
     exit 0
@@ -22,5 +26,5 @@ extra_flags+=("--endpoints=${endpoints}" "--debug=true")
 # We use 'sync' to ensure memory buffers are flushed to disk
 # so we reduce the chances that the "member_removal.log" file is empty.
 # ref: https://man7.org/linux/man-pages/man1/sync.1.html
-etcdctl member remove "$(cat "${ETCD_DATA_DIR}/member_id")" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
+etcdctl member remove "$(get_member_id)" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
 sync -d "$(dirname "$ETCD_DATA_DIR")/member_removal.log"

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
@@ -13,6 +13,10 @@ set -o nounset
 # Load etcd environment settings
 . /opt/bitnami/scripts/etcd-env.sh
 
+if is_boolean_yes "$ETCD_DISABLE_PRESTOP"; then
+    return 0
+fi
+
 endpoints="$(etcdctl_get_endpoints true)"
 if is_empty_value "${endpoints}"; then
     exit 0
@@ -22,5 +26,5 @@ extra_flags+=("--endpoints=${endpoints}" "--debug=true")
 # We use 'sync' to ensure memory buffers are flushed to disk
 # so we reduce the chances that the "member_removal.log" file is empty.
 # ref: https://man7.org/linux/man-pages/man1/sync.1.html
-etcdctl member remove "$(cat "${ETCD_DATA_DIR}/member_id")" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
+etcdctl member remove "$(get_member_id)" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
 sync -d "$(dirname "$ETCD_DATA_DIR")/member_removal.log"

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/etcd/prestop.sh
@@ -13,6 +13,10 @@ set -o nounset
 # Load etcd environment settings
 . /opt/bitnami/scripts/etcd-env.sh
 
+if is_boolean_yes "$ETCD_DISABLE_PRESTOP"; then
+    return 0
+fi
+
 endpoints="$(etcdctl_get_endpoints true)"
 if is_empty_value "${endpoints}"; then
     exit 0
@@ -22,5 +26,5 @@ extra_flags+=("--endpoints=${endpoints}" "--debug=true")
 # We use 'sync' to ensure memory buffers are flushed to disk
 # so we reduce the chances that the "member_removal.log" file is empty.
 # ref: https://man7.org/linux/man-pages/man1/sync.1.html
-etcdctl member remove "$(cat "${ETCD_DATA_DIR}/member_id")" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
+etcdctl member remove "$(get_member_id)" "${extra_flags[@]}" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log"
 sync -d "$(dirname "$ETCD_DATA_DIR")/member_removal.log"


### PR DESCRIPTION
Signed-off-by: shaoyue.chen <shaoyue.chen@zilliz.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- Remove the `member_id` persist.
- No self removal when pod stop.
- When adding new node, etcdctl will only send requests to active nodes

**Benefits**

- Fix `member_id`, `removal log ` persistence issues.
- In kubernetes, you can kill any number of pods, the etcd cluster can always go back to healthy state. There will be no need for disaster recovery any more
- Fix scaling up failure when some pod is down (while the etcd cluster is healthy)
- Quick scale up: scale up directly to any numbers: eg:  you can scale from 3 nodes to 11 nodes directly instead of scale from 3 to 4 then 4 to 5...

**Possible drawbacks**

- When shrinking the size of etcd-cluster (aka scale down), one have to manually remove the old members from cluster using `etcdctl member remove`

**Applicable issues**

#39 

**Additional information**

see: #39
