### PR TITLE
Fix cluster id mismatch when startup

### DIFF
--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
@@ -20,12 +20,9 @@ set -o pipefail
 if [[ -f "$ETCD_NEW_MEMBERS_ENV_FILE" ]]; then
     debug "Loading env vars of existing cluster"
     . "$ETCD_NEW_MEMBERS_ENV_FILE"
-else
-    # We do not rely on the original value of ETCD_INITIAL_CLUSTER even
-    # when bootstrapping a new cluster since we cannot assume
-    # that all nodes will come-up healthy
-    ETCD_INITIAL_CLUSTER="$(recalculate_initial_cluster)"
-    export ETCD_INITIAL_CLUSTER
+    # We rely on the original value of ETCD_INITIAL_CLUSTER
+    # when bootstrapping a new cluster since 
+    # we need all intial members to calcualte a same cluster_id
 fi
 
 declare -a cmd=("etcd")

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
@@ -20,12 +20,9 @@ set -o pipefail
 if [[ -f "$ETCD_NEW_MEMBERS_ENV_FILE" ]]; then
     debug "Loading env vars of existing cluster"
     . "$ETCD_NEW_MEMBERS_ENV_FILE"
-else
-    # We do not rely on the original value of ETCD_INITIAL_CLUSTER even
-    # when bootstrapping a new cluster since we cannot assume
-    # that all nodes will come-up healthy
-    ETCD_INITIAL_CLUSTER="$(recalculate_initial_cluster)"
-    export ETCD_INITIAL_CLUSTER
+    # We rely on the original value of ETCD_INITIAL_CLUSTER
+    # when bootstrapping a new cluster since 
+    # we need all intial members to calcualte a same cluster_id
 fi
 
 declare -a cmd=("etcd")

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/etcd/run.sh
@@ -21,11 +21,9 @@ if [[ -f "$ETCD_NEW_MEMBERS_ENV_FILE" ]]; then
     debug "Loading env vars of existing cluster"
     . "$ETCD_NEW_MEMBERS_ENV_FILE"
 else
-    # We do not rely on the original value of ETCD_INITIAL_CLUSTER even
-    # when bootstrapping a new cluster since we cannot assume
-    # that all nodes will come-up healthy
-    ETCD_INITIAL_CLUSTER="$(recalculate_initial_cluster)"
-    export ETCD_INITIAL_CLUSTER
+    # We rely on the original value of ETCD_INITIAL_CLUSTER
+    # when bootstrapping a new cluster since 
+    # we need all intial members to calcualte a same cluster_id
 fi
 
 declare -a cmd=("etcd")


### PR DESCRIPTION
Signed-off-by: shaoyue.chen <shaoyue.chen@zilliz.com>
cc @mdhont

**Description of the change**

Use original `ETCD_INITIAL_CLUSTER` when bootstrap new cluster

**Benefits**

Avoid `cluster id mismatch` issue when bootstrap new cluster

**Applicable issues**

- Fixes #45
