### PR TITLE
Fix ETCD_ACTIVE_ENDPOINTS environment variable not found issue

### DIFF
--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"s
+                info "Updating member in existing cluster"
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"

--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"
+                info "Updating member in existing cluster"s
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
@@ -765,7 +765,7 @@ get_member_id() {
     local -a extra_flags
 
     local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
-    if [ -z ${etcd_active_endpoints} ]; then
+    if is_empty_value "${etcd_active_endpoints}"; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -764,7 +764,8 @@ get_member_id() {
     local ret
     local -a extra_flags
 
-    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+    local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
+    if [ -z ${etcd_active_endpoints} ]; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -398,7 +398,7 @@ is_new_etcd_cluster() {
 # Arguments:
 #   None
 # Returns:
-#   Number
+#   List of Numbers (active_endpoints, cluster_size)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo $active_endpoints
+    echo "${active_endpoints} ${cluster_size}"
 }
 
 ########################
@@ -438,7 +438,8 @@ setup_etcd_active_endpoints() {
 ########################
 is_healthy_etcd_cluster() {
     local return_value=0
-    local active_endpoints=$(setup_etcd_active_endpoints)
+    local active_endpoints cluster_size
+    read -r active_endpoints cluster_size <<< $(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then

--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,16 +392,15 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   Boolean
+#   Number
 ########################
-is_healthy_etcd_cluster() {
-    local return_value=0
+setup_etcd_active_endpoints() {
     local active_endpoints=0
     local -a extra_flags active_endpoints_array
     local -a endpoints_array=()
@@ -425,6 +424,21 @@ is_healthy_etcd_cluster() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
+    echo $active_endpoints
+}
+
+########################
+# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Globals:
+#   ETCD_*
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_healthy_etcd_cluster() {
+    local return_value=0
+    local active_endpoints=$(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then
@@ -748,6 +762,11 @@ get_member_id() {
     fi
     local ret
     local -a extra_flags
+
+    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+        setup_etcd_active_endpoints >/dev/null 2>&1
+    fi
+
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
     extra_flags+=("--endpoints=${ETCD_ACTIVE_ENDPOINTS}")
     ret=$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1 }')

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"s
+                info "Updating member in existing cluster"
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"
+                info "Updating member in existing cluster"s
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
@@ -765,7 +765,7 @@ get_member_id() {
     local -a extra_flags
 
     local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
-    if [ -z ${etcd_active_endpoints} ]; then
+    if is_empty_value "${etcd_active_endpoints}"; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -764,7 +764,8 @@ get_member_id() {
     local ret
     local -a extra_flags
 
-    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+    local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
+    if [ -z ${etcd_active_endpoints} ]; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -398,7 +398,7 @@ is_new_etcd_cluster() {
 # Arguments:
 #   None
 # Returns:
-#   Number
+#   List of Numbers (active_endpoints, cluster_size)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo $active_endpoints
+    echo "${active_endpoints} ${cluster_size}"
 }
 
 ########################
@@ -438,7 +438,8 @@ setup_etcd_active_endpoints() {
 ########################
 is_healthy_etcd_cluster() {
     local return_value=0
-    local active_endpoints=$(setup_etcd_active_endpoints)
+    local active_endpoints cluster_size
+    read -r active_endpoints cluster_size <<< $(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,16 +392,15 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   Boolean
+#   Number
 ########################
-is_healthy_etcd_cluster() {
-    local return_value=0
+setup_etcd_active_endpoints() {
     local active_endpoints=0
     local -a extra_flags active_endpoints_array
     local -a endpoints_array=()
@@ -425,6 +424,21 @@ is_healthy_etcd_cluster() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
+    echo $active_endpoints
+}
+
+########################
+# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Globals:
+#   ETCD_*
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_healthy_etcd_cluster() {
+    local return_value=0
+    local active_endpoints=$(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then
@@ -748,6 +762,11 @@ get_member_id() {
     fi
     local ret
     local -a extra_flags
+
+    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+        setup_etcd_active_endpoints >/dev/null 2>&1
+    fi
+
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
     extra_flags+=("--endpoints=${ETCD_ACTIVE_ENDPOINTS}")
     ret=$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1 }')

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"s
+                info "Updating member in existing cluster"
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -689,7 +689,7 @@ etcd_initialize() {
                 replace_in_file "$ETCD_NEW_MEMBERS_ENV_FILE" "^" "export "
                 etcd_store_member_id
             elif ! is_empty_value "$member_id"; then
-                info "Updating member in existing cluster"
+                info "Updating member in existing cluster"s
                 export ETCD_INITIAL_CLUSTER_STATE=existing
                 [[ -f "$ETCD_CONF_FILE" ]] && etcd_conf_write "initial-cluster-state" "$ETCD_INITIAL_CLUSTER_STATE"
                 read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
@@ -765,7 +765,7 @@ get_member_id() {
     local -a extra_flags
 
     local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
-    if [ -z ${etcd_active_endpoints} ]; then
+    if is_empty_value "${etcd_active_endpoints}"; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -764,7 +764,8 @@ get_member_id() {
     local ret
     local -a extra_flags
 
-    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+    local etcd_active_endpoints=${ETCD_ACTIVE_ENDPOINTS:-}
+    if [ -z ${etcd_active_endpoints} ]; then
         setup_etcd_active_endpoints >/dev/null 2>&1
     fi
 

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -398,7 +398,7 @@ is_new_etcd_cluster() {
 # Arguments:
 #   None
 # Returns:
-#   Number
+#   List of Numbers (active_endpoints, cluster_size)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo $active_endpoints
+    echo "${active_endpoints} ${cluster_size}"
 }
 
 ########################
@@ -438,7 +438,8 @@ setup_etcd_active_endpoints() {
 ########################
 is_healthy_etcd_cluster() {
     local return_value=0
-    local active_endpoints=$(setup_etcd_active_endpoints)
+    local active_endpoints cluster_size
+    read -r active_endpoints cluster_size <<< $(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,16 +392,15 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   Boolean
+#   Number
 ########################
-is_healthy_etcd_cluster() {
-    local return_value=0
+setup_etcd_active_endpoints() {
     local active_endpoints=0
     local -a extra_flags active_endpoints_array
     local -a endpoints_array=()
@@ -425,6 +424,21 @@ is_healthy_etcd_cluster() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
+    echo $active_endpoints
+}
+
+########################
+# Checks if there are enough active members, will also set ETCD_ACTIVE_ENDPOINTS
+# Globals:
+#   ETCD_*
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_healthy_etcd_cluster() {
+    local return_value=0
+    local active_endpoints=$(setup_etcd_active_endpoints)
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then
@@ -748,6 +762,11 @@ get_member_id() {
     fi
     local ret
     local -a extra_flags
+
+    if is_empty_value "${ETCD_ACTIVE_ENDPOINTS}"; then
+        setup_etcd_active_endpoints >/dev/null 2>&1
+    fi
+
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
     extra_flags+=("--endpoints=${ETCD_ACTIVE_ENDPOINTS}")
     ret=$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1 }')


### PR DESCRIPTION

**Description of the change**
Fix the issue created by PR https://github.com/bitnami/bitnami-docker-etcd/pull/42
Create a `setup_etcd_active_endpoints` function to  set `ETCD_ACTIVE_ENDPOINTS` env.

And call this function in `get_member_id` function.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Fix etcd startup issue if `ETCD_DISABLE_STORE_MEMBER_ID` set to `yes`

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
PR https://github.com/bitnami/bitnami-docker-etcd/pull/42