### PR TITLE
Improve getting member_id

### DIFF
--- a/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -316,8 +316,7 @@ etcd_store_member_id() {
     is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
     if retry_while "etcdctl ${extra_flags[*]} member list" >/dev/null 2>&1; then
         while is_empty_value "$member_id"; do
-            read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
-            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "${advertised_array[0]}" | awk -F "," '{ print $1}' || true)"
+            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1}' || true)"
         done
         # We use 'sync' to ensure memory buffers are flushed to disk
         # so we reduce the chances that the "member_id" file is empty.

--- a/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -316,8 +316,7 @@ etcd_store_member_id() {
     is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
     if retry_while "etcdctl ${extra_flags[*]} member list" >/dev/null 2>&1; then
         while is_empty_value "$member_id"; do
-            read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
-            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "${advertised_array[0]}" | awk -F "," '{ print $1}' || true)"
+            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1}' || true)"
         done
         # We use 'sync' to ensure memory buffers are flushed to disk
         # so we reduce the chances that the "member_id" file is empty.

--- a/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -316,8 +316,7 @@ etcd_store_member_id() {
     is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
     if retry_while "etcdctl ${extra_flags[*]} member list" >/dev/null 2>&1; then
         while is_empty_value "$member_id"; do
-            read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
-            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "${advertised_array[0]}" | awk -F "," '{ print $1}' || true)"
+            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1}' || true)"
         done
         # We use 'sync' to ensure memory buffers are flushed to disk
         # so we reduce the chances that the "member_id" file is empty.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Sometimes, I see this code loop forever 
https://github.com/bitnami/bitnami-docker-etcd/blob/9f71d5ebb9cdc34bedb0e47d090dc2da9399b86b/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh#L332
```sh
        while is_empty_value "$member_id"; do
            read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
            member_id="$(etcdctl "${extra_flags[@]}" member list | grep -w "${advertised_array[0]}" | awk -F "," '{ print $1}' || true)"
        done
```

Because the result of listing member as below:
```
15f876fd44ecd87, unstarted, , http://etcd-2.etcd-headless.default.svc.cluster.local:2380, , false
```
but the `${advertised_array[0]}` is `...:2379`, that why we can not get member_id

One more point, we should have same logic with https://github.com/bitnami/bitnami-docker-etcd/blob/98e55cfee4d47a5cdb479d12f212002dfb9f9af8/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh#L753

```sh
get_member_id() {                                                                                                                                                                              
 # ...
  ret=$(etcdctl "${extra_flags[@]}" member list | grep -w "$ETCD_INITIAL_ADVERTISE_PEER_URLS" | awk -F "," '{ print $1 }') 

```

Seems we have to initial variable `ETCD_INITIAL_ADVERTISE_PEER_URLS`

**Benefits**

Get member_id fast and correct when it was added to cluster

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->



**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
